### PR TITLE
fix-item-component-values-persist-across-world-reloads

### DIFF
--- a/packages/client/src/layers/react/components/InventoryHud.tsx
+++ b/packages/client/src/layers/react/components/InventoryHud.tsx
@@ -72,7 +72,6 @@ export function registerInventoryHud() {
             if (!voxelType) return { ...acc };
             acc[voxelType] = acc[voxelType] ?? 0;
             if (curr.type === UpdateType.Exit) {
-              acc[voxelType]--; // why do we decrement here? we don't increment before this line
               return { ...acc };
             }
 
@@ -178,8 +177,13 @@ export function registerInventoryHud() {
           InventoryIndex,
           holdingVoxelType
         )?.value;
-        if (!holdingVoxelTypeSlot) {
-          console.warn("holding voxel has no slot", holdingVoxelType);
+
+        // since holdingVoxelTypeSlot can be 0, we cannot use !holdingVoxelTypeSlot
+        if (holdingVoxelTypeSlot === undefined) {
+          console.warn(
+            "we are not holding a voxel of type",
+            VoxelTypeIdToKey[holdingVoxelType]
+          );
           return;
         }
         setComponent(InventoryIndex, holdingVoxelType, { value: slot });


### PR DESCRIPTION
fixes the problem with inventoryIndex being persisted across world reloads(identified in https://github.com/tenetxyz/voxel-aw/pull/25)
- I also fixed a small bug where you couldn't move an item that was in your first inventory slot