### PR TITLE
spawn on correct side of the block face

### DIFF
--- a/packages/client/src/layers/noa/systems/createInputSystem.ts
+++ b/packages/client/src/layers/noa/systems/createInputSystem.ts
@@ -8,10 +8,11 @@ import { getNoaComponent, getNoaComponentStrict } from "../engine/components/uti
 import { NoaLayer } from "../types";
 import { toast } from "react-toastify";
 import { Creation } from "../../react/components/CreationStore";
-import { getCoordOfVoxelOnFaceYouTargeted, getTargetedVoxelCoord } from "../../../utils/voxels";
+import { calculateMinMax, getCoordOfVoxelOnFaceYouTargeted, getTargetedVoxelCoord } from "../../../utils/voxels";
 import { NotificationIcon } from "../components/persistentNotification";
 import { BEDROCK_ID } from "../../network/api/terrain/occurrence";
 import { DEFAULT_BLOCK_TEST_DISTANCE } from "../setup/setupNoaEngine";
+import { calculateCornersFromTargetedBlock, TargetedBlock } from "./createSpawnCreationOverlaySystem";
 
 export function createInputSystem(network: NetworkLayer, noaLayer: NoaLayer) {
   const {
@@ -313,11 +314,14 @@ export function createInputSystem(network: NetworkLayer, noaLayer: NoaLayer) {
     if (!noa.container.hasPointerLock) {
       return;
     }
-    const creationToSpawn: Creation | undefined = getComponentValue(SpawnCreation, SingletonEntity)?.creation;
-    if (creationToSpawn === undefined) {
+    const creation: Creation | undefined = getComponentValue(SpawnCreation, SingletonEntity)?.creation;
+    if (creation === undefined) {
       return;
     }
-    const lowerSouthWestCorner = getCoordOfVoxelOnFaceYouTargeted(noa);
-    spawnCreation(lowerSouthWestCorner, (creationToSpawn as Creation).creationId);
+    // @ts-nocheck
+    const { corner1, corner2 } = calculateCornersFromTargetedBlock(creation, noa.targetedBlock);
+    const { minX, minY, minZ } = calculateMinMax(corner1, corner2);
+
+    spawnCreation({ x: minX, y: minY, z: minZ }, (creation as Creation).creationId);
   });
 }

--- a/packages/client/src/utils/voxels.ts
+++ b/packages/client/src/utils/voxels.ts
@@ -22,15 +22,3 @@ export const getTargetedVoxelCoord = (noa: Engine): VoxelCoord => {
     z,
   };
 };
-
-export const getCoordOfVoxelOnFaceYouTargeted = (noa: Engine): VoxelCoord => {
-  // adjacent just means the coord on the side of the block face you targeted
-  const x = noa.targetedBlock.adjacent[0];
-  const y = noa.targetedBlock.adjacent[1];
-  const z = noa.targetedBlock.adjacent[2];
-  return {
-    x,
-    y,
-    z,
-  };
-};


### PR DESCRIPTION
if you are facing a wall from the north side, and try to spawn the creation, it will spawn on the north side of the wall.
if you are facing a wall from the east side, and try to spawn the creation, it will spawn on the east side of the wall.
etc.

Basically, when you spawn the creation, the outline will no longer clip into the wall