### PR TITLE
Remove hasKeys module and replace with a flag

### DIFF
--- a/packages/extension-contracts/.env
+++ b/packages/extension-contracts/.env
@@ -5,6 +5,7 @@
 # development. Please do not commit changes to this file!
 #
 # Anvil default private key:
-# TODO: Update private key to NOT be root key once we figure out non-root module installation
-# PRIVATE_KEY=0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
-PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+PRIVATE_KEY=0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
+# TODO: The below private key is a root key that should only be used when you need
+# a module. This can be removed once we support non-root modules
+# PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80

--- a/packages/extension-contracts/mud.config.ts
+++ b/packages/extension-contracts/mud.config.ts
@@ -4,7 +4,7 @@ import { resolveTableId } from "@latticexyz/config";
 const KeysInTableModule_ADDRESS = "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9";
 
 export default mudConfig({
-  namespace: "tenet", // TODO: Make different namespace once we have non-root modules working
+  namespace: "extension",
   enums: {
     BlockDirection: ["None", "Up", "Down", "North", "South", "East", "West"],
   },
@@ -17,6 +17,7 @@ export default mudConfig({
       schema: {
         isActive: "bool",
         direction: "BlockDirection",
+        hasValue: "bool", // TODO: Remove this once we can install non-root modules
       },
     },
     SignalSource: {
@@ -26,6 +27,7 @@ export default mudConfig({
       },
       schema: {
         isNatural: "bool",
+        hasValue: "bool", // TODO: Remove this once we can install non-root modules
       },
     },
     Powered: {
@@ -36,6 +38,7 @@ export default mudConfig({
       schema: {
         isActive: "bool",
         direction: "BlockDirection",
+        hasValue: "bool", // TODO: Remove this once we can install non-root modules
       },
     },
     InvertedSignal: {
@@ -46,33 +49,35 @@ export default mudConfig({
       schema: {
         isActive: "bool",
         direction: "BlockDirection",
+        hasValue: "bool", // TODO: Remove this once we can install non-root modules
       },
     },
   },
   modules: [
-    {
-      name: "KeysInTableModule",
-      address: KeysInTableModule_ADDRESS,
-      root: true,
-      args: [resolveTableId("Signal")],
-    },
-    {
-      name: "KeysInTableModule",
-      address: KeysInTableModule_ADDRESS,
-      root: true,
-      args: [resolveTableId("SignalSource")],
-    },
-    {
-      name: "KeysInTableModule",
-      address: KeysInTableModule_ADDRESS,
-      root: true,
-      args: [resolveTableId("Powered")],
-    },
-    {
-      name: "KeysInTableModule",
-      address: KeysInTableModule_ADDRESS,
-      root: true,
-      args: [resolveTableId("InvertedSignal")],
-    },
+    // TODO: Re-enable when we have a way to install non-root modules
+    // {
+    //   name: "KeysInTableModule",
+    //   address: KeysInTableModule_ADDRESS,
+    //   root: true,
+    //   args: [resolveTableId("Signal")],
+    // },
+    // {
+    //   name: "KeysInTableModule",
+    //   address: KeysInTableModule_ADDRESS,
+    //   root: true,
+    //   args: [resolveTableId("SignalSource")],
+    // },
+    // {
+    //   name: "KeysInTableModule",
+    //   address: KeysInTableModule_ADDRESS,
+    //   root: true,
+    //   args: [resolveTableId("Powered")],
+    // },
+    // {
+    //   name: "KeysInTableModule",
+    //   address: KeysInTableModule_ADDRESS,
+    //   root: true,
+    //   args: [resolveTableId("InvertedSignal")],
+    // },
   ],
 });

--- a/packages/extension-contracts/package.json
+++ b/packages/extension-contracts/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "mud": "node ../../node_modules/@latticexyz/cli/dist/mud.js",
     "build": "forge clean && forge build",
-    "deploy": "yarn run initialize && yarn mud deploy --createNamespace false --worldAddress 0x5FbDB2315678afecb367f032d93F642f64180aa3",
+    "deploy": "yarn run initialize && yarn mud deploy --installDefaultModules false --worldAddress 0x5FbDB2315678afecb367f032d93F642f64180aa3",
     "deploy:hackathon": "yarn run initialize && yarn mud deploy --profile=hackathon-testnet",
     "deploy:testnet": "yarn run initialize && yarn mud deploy --profile=lattice-testnet",
     "dev": "yarn mud dev-contracts --tsgenOutput ./client",

--- a/packages/extension-contracts/script/PostDeploy.s.sol
+++ b/packages/extension-contracts/script/PostDeploy.s.sol
@@ -16,70 +16,74 @@ contract PostDeploy is Script {
     // ------------------ EXAMPLES ------------------
     // Call world init function
     IWorld world = IWorld(worldAddress);
-    world.tenet_ExtensionInitSys_init();
+    world.extension_ExtensionInitSys_init();
     // Note: These have to be here instead of ExtensionInitSystem as they have be called from the deployer account
     // otherwise the msgSender is not the namespace owner
     registerVoxelType(
       "Sand",
       SandID,
       SandTexture,
-      world.tenet_ExtensionInitSys_sandVariantSelector.selector,
+      world.extension_ExtensionInitSys_sandVariantSelector.selector,
       worldAddress
     );
     registerVoxelType(
       "Log",
       LogID,
       LogTexture,
-      IWorld(world).tenet_ExtensionInitSys_logVariantSelector.selector,
+      IWorld(world).extension_ExtensionInitSys_logVariantSelector.selector,
       worldAddress
     );
     registerVoxelType(
       "Orange Flower",
       OrangeFlowerID,
       OrangeFlowerTexture,
-      IWorld(world).tenet_ExtensionInitSys_orangeFlowerVariantSelector.selector,
+      IWorld(world).extension_ExtensionInitSys_orangeFlowerVariantSelector.selector,
       worldAddress
     );
     registerVoxelType(
       "Signal",
       SignalID,
       SignalOffTexture,
-      IWorld(world).tenet_ExtensionInitSys_signalVariantSelector.selector,
+      IWorld(world).extension_SignalSystem_signalVariantSelector.selector,
       worldAddress
     );
     registerVoxelType(
       "Signal Source",
       SignalSourceID,
       SignalSourceTexture,
-      IWorld(world).tenet_ExtensionInitSys_signalSourceVariantSelector.selector,
+      IWorld(world).extension_SignalSourceSyst_signalSourceVariantSelector.selector,
       worldAddress
     );
     registerVoxelType(
       "Inverted Signal",
       InvertedSignalID,
       SignalOnTexture,
-      IWorld(world).tenet_ExtensionInitSys_invertedSignalVariantSelector.selector,
+      IWorld(world).extension_InvertedSignalSy_invertedSignalVariantSelector.selector,
       worldAddress
     );
 
     registerExtension(
       "SignalSourceSystem",
-      IWorld(worldAddress).tenet_SignalSourceSyst_eventHandler.selector,
+      IWorld(worldAddress).extension_SignalSourceSyst_eventHandler.selector,
       worldAddress
     );
-    registerExtension("SignalSystem", IWorld(worldAddress).tenet_SignalSystem_eventHandler.selector, worldAddress);
+    registerExtension("SignalSystem", IWorld(worldAddress).extension_SignalSystem_eventHandler.selector, worldAddress);
     // need to call registerExtension() in the world contract with PoweredSystem
-    registerExtension("PoweredSystem", IWorld(worldAddress).tenet_PoweredSystem_eventHandler.selector, worldAddress);
+    registerExtension(
+      "PoweredSystem",
+      IWorld(worldAddress).extension_PoweredSystem_eventHandler.selector,
+      worldAddress
+    );
     registerExtension(
       "Inverted Signal System",
-      IWorld(worldAddress).tenet_InvertedSignalSy_eventHandler.selector,
+      IWorld(worldAddress).extension_InvertedSignalSy_eventHandler.selector,
       worldAddress
     );
 
     registerClassifier(
       "AND Gate",
       "Classifies if this creation is an AND Gate",
-      IWorld(worldAddress).tenet_AndGateSystem_classify.selector,
+      IWorld(worldAddress).extension_AndGateSystem_classify.selector,
       worldAddress
     );
     vm.stopBroadcast();

--- a/packages/extension-contracts/src/Utils.sol
+++ b/packages/extension-contracts/src/Utils.sol
@@ -3,37 +3,25 @@ pragma solidity >=0.8.0;
 import { Position, PositionData, PositionTableId } from "@tenetxyz/contracts/src/codegen/tables/Position.sol";
 import { VoxelCoord } from "@tenetxyz/contracts/src/Types.sol";
 import { hasKey } from "@latticexyz/world/src/modules/keysintable/hasKey.sol";
-import { SignalTableId, SignalSourceTableId, PoweredTableId, InvertedSignalTableId } from "./codegen/Tables.sol";
+import { Signal, SignalSource, Powered, InvertedSignal } from "./codegen/Tables.sol";
 import { BlockDirection } from "./codegen/Types.sol";
 import { CLEAR_COORD_SIG, BUILD_SIG } from "@tenetxyz/contracts/src/constants.sol";
 import { getUniqueEntity } from "@latticexyz/world/src/modules/uniqueentity/getUniqueEntity.sol";
 
 function entityIsSignal(bytes32 entity, bytes16 callerNamespace) view returns (bool) {
-  bytes32[] memory keyTuple = new bytes32[](2);
-  keyTuple[0] = bytes32((callerNamespace));
-  keyTuple[1] = bytes32((entity));
-  return hasKey(SignalTableId, keyTuple);
+  return Signal.get(callerNamespace, entity).hasValue;
 }
 
 function entityIsSignalSource(bytes32 entity, bytes16 callerNamespace) view returns (bool) {
-  bytes32[] memory keyTuple = new bytes32[](2);
-  keyTuple[0] = bytes32((callerNamespace));
-  keyTuple[1] = bytes32((entity));
-  return hasKey(SignalSourceTableId, keyTuple);
+  return SignalSource.get(callerNamespace, entity).hasValue;
 }
 
 function entityIsPowered(bytes32 entity, bytes16 callerNamespace) view returns (bool) {
-  bytes32[] memory keyTuple = new bytes32[](2);
-  keyTuple[0] = bytes32((callerNamespace));
-  keyTuple[1] = bytes32((entity));
-  return hasKey(PoweredTableId, keyTuple);
+  return Powered.get(callerNamespace, entity).hasValue;
 }
 
 function entityIsInvertedSignal(bytes32 entity, bytes16 callerNamespace) view returns (bool) {
-  bytes32[] memory keyTuple = new bytes32[](2);
-  keyTuple[0] = bytes32((callerNamespace));
-  keyTuple[1] = bytes32((entity));
-  return hasKey(InvertedSignalTableId, keyTuple);
+  return InvertedSignal.get(callerNamespace, entity).hasValue;
 }
 
 function getEntityPositionStrict(bytes32 entity) view returns (PositionData memory) {

--- a/packages/extension-contracts/src/constants.sol
+++ b/packages/extension-contracts/src/constants.sol
@@ -1,0 +1,1 @@
+bytes16 constant EXTENSION_NAMESPACE = bytes16("extension");

--- a/packages/extension-contracts/src/systems/ExtensionInitSystem.sol
+++ b/packages/extension-contracts/src/systems/ExtensionInitSystem.sol
@@ -5,44 +5,19 @@ import { IWorld } from "../codegen/world/IWorld.sol";
 import { SignalData, InvertedSignalData } from "../codegen/Tables.sol";
 import { VoxelVariantsKey } from "../types.sol";
 import { defineVoxels, SandID, LogID, OrangeFlowerID, SignalOffID, SignalOnID, SignalSourceID } from "../prototypes/Voxels.sol";
-import { TENET_NAMESPACE } from "@tenetxyz/contracts/src/constants.sol";
+import { EXTENSION_NAMESPACE } from "../Constants.sol";
 
 contract ExtensionInitSystem is System {
   function sandVariantSelector(bytes32 entity) public returns (VoxelVariantsKey memory) {
-    return VoxelVariantsKey({ voxelVariantNamespace: TENET_NAMESPACE, voxelVariantId: SandID });
+    return VoxelVariantsKey({ voxelVariantNamespace: EXTENSION_NAMESPACE, voxelVariantId: SandID });
   }
 
   function logVariantSelector(bytes32 entity) public returns (VoxelVariantsKey memory) {
-    return VoxelVariantsKey({ voxelVariantNamespace: TENET_NAMESPACE, voxelVariantId: LogID });
+    return VoxelVariantsKey({ voxelVariantNamespace: EXTENSION_NAMESPACE, voxelVariantId: LogID });
   }
 
   function orangeFlowerVariantSelector(bytes32 entity) public returns (VoxelVariantsKey memory) {
-    return VoxelVariantsKey({ voxelVariantNamespace: TENET_NAMESPACE, voxelVariantId: OrangeFlowerID });
-  }
-
-  function signalVariantSelector(bytes32 entity) public returns (VoxelVariantsKey memory) {
-    SignalData memory signalData = IWorld(_world()).tenet_SignalSystem_getOrCreateSignal(entity);
-    if (signalData.isActive) {
-      return VoxelVariantsKey({ voxelVariantNamespace: TENET_NAMESPACE, voxelVariantId: SignalOnID });
-    } else {
-      return VoxelVariantsKey({ voxelVariantNamespace: TENET_NAMESPACE, voxelVariantId: SignalOffID });
-    }
-  }
-
-  function invertedSignalVariantSelector(bytes32 entity) public returns (VoxelVariantsKey memory) {
-    InvertedSignalData memory invertedSignalData = IWorld(_world()).tenet_InvertedSignalSy_getOrCreateInvertedSignal(
-      entity
-    );
-    if (invertedSignalData.isActive) {
-      return VoxelVariantsKey({ voxelVariantNamespace: TENET_NAMESPACE, voxelVariantId: SignalOnID });
-    } else {
-      return VoxelVariantsKey({ voxelVariantNamespace: TENET_NAMESPACE, voxelVariantId: SignalOffID });
-    }
-  }
-
-  function signalSourceVariantSelector(bytes32 entity) public returns (VoxelVariantsKey memory) {
-    IWorld(_world()).tenet_SignalSourceSyst_getOrCreateSignalSource(entity);
-    return VoxelVariantsKey({ voxelVariantNamespace: TENET_NAMESPACE, voxelVariantId: SignalSourceID });
+    return VoxelVariantsKey({ voxelVariantNamespace: EXTENSION_NAMESPACE, voxelVariantId: OrangeFlowerID });
   }
 
   function init() public {

--- a/packages/extension-contracts/src/systems/InvertedSignalSystem.sol
+++ b/packages/extension-contracts/src/systems/InvertedSignalSystem.sol
@@ -9,8 +9,20 @@ import { BlockDirection } from "../codegen/Types.sol";
 import { PositionData } from "@tenetxyz/contracts/src/codegen/tables/Position.sol";
 import { getCallerNamespace } from "@tenetxyz/contracts/src/SharedUtils.sol";
 import { calculateBlockDirection, getOppositeDirection, getEntityPositionStrict, entityIsSignal, entityIsInvertedSignal, entityIsPowered, entityIsSignalSource } from "../Utils.sol";
+import { SignalOffID, SignalOnID } from "../prototypes/Voxels.sol";
+import { VoxelVariantsKey } from "../types.sol";
+import { EXTENSION_NAMESPACE } from "../Constants.sol";
 
 contract InvertedSignalSystem is System {
+  function invertedSignalVariantSelector(bytes32 entity) public returns (VoxelVariantsKey memory) {
+    InvertedSignalData memory invertedSignalData = getOrCreateInvertedSignal(entity);
+    if (invertedSignalData.isActive) {
+      return VoxelVariantsKey({ voxelVariantNamespace: EXTENSION_NAMESPACE, voxelVariantId: SignalOnID });
+    } else {
+      return VoxelVariantsKey({ voxelVariantNamespace: EXTENSION_NAMESPACE, voxelVariantId: SignalOffID });
+    }
+  }
+
   function getOrCreateInvertedSignal(bytes32 entity) public returns (InvertedSignalData memory) {
     bytes16 callerNamespace = getCallerNamespace(_msgSender());
 
@@ -18,7 +30,7 @@ contract InvertedSignalSystem is System {
       InvertedSignal.set(
         callerNamespace,
         entity,
-        InvertedSignalData({ isActive: true, direction: BlockDirection.None })
+        InvertedSignalData({ isActive: true, direction: BlockDirection.None, hasValue: true })
       );
     }
 

--- a/packages/extension-contracts/src/systems/PoweredSystem.sol
+++ b/packages/extension-contracts/src/systems/PoweredSystem.sol
@@ -16,7 +16,11 @@ contract PoweredSystem is System {
     bytes16 callerNamespace = getCallerNamespace(_msgSender());
 
     if (!entityIsPowered(entity, callerNamespace)) {
-      Powered.set(callerNamespace, entity, PoweredData({ isActive: false, direction: BlockDirection.None }));
+      Powered.set(
+        callerNamespace,
+        entity,
+        PoweredData({ isActive: false, direction: BlockDirection.None, hasValue: true })
+      );
     }
 
     return Powered.get(callerNamespace, entity);
@@ -29,7 +33,11 @@ contract PoweredSystem is System {
       !entityIsSignal(entity, callerNamespace) &&
       !entityIsSignalSource(entity, callerNamespace)
     ) {
-      Powered.set(callerNamespace, entity, PoweredData({ isActive: false, direction: BlockDirection.None }));
+      Powered.set(
+        callerNamespace,
+        entity,
+        PoweredData({ isActive: false, direction: BlockDirection.None, hasValue: true })
+      );
     }
   }
 

--- a/packages/extension-contracts/src/systems/SignalSystem.sol
+++ b/packages/extension-contracts/src/systems/SignalSystem.sol
@@ -10,13 +10,29 @@ import { BlockDirection } from "../codegen/Types.sol";
 import { PositionData } from "@tenetxyz/contracts/src/codegen/tables/Position.sol";
 import { getCallerNamespace } from "@tenetxyz/contracts/src/SharedUtils.sol";
 import { calculateBlockDirection, getOppositeDirection, getEntityPositionStrict, entityIsSignal, entityIsSignalSource, entityIsInvertedSignal } from "../Utils.sol";
+import { SignalOffID, SignalOnID } from "../prototypes/Voxels.sol";
+import { VoxelVariantsKey } from "../types.sol";
+import { EXTENSION_NAMESPACE } from "../Constants.sol";
 
 contract SignalSystem is System {
+  function signalVariantSelector(bytes32 entity) public returns (VoxelVariantsKey memory) {
+    SignalData memory signalData = getOrCreateSignal(entity);
+    if (signalData.isActive) {
+      return VoxelVariantsKey({ voxelVariantNamespace: EXTENSION_NAMESPACE, voxelVariantId: SignalOnID });
+    } else {
+      return VoxelVariantsKey({ voxelVariantNamespace: EXTENSION_NAMESPACE, voxelVariantId: SignalOffID });
+    }
+  }
+
   function getOrCreateSignal(bytes32 entity) public returns (SignalData memory) {
     bytes16 callerNamespace = getCallerNamespace(_msgSender());
 
     if (!entityIsSignal(entity, callerNamespace)) {
-      Signal.set(callerNamespace, entity, SignalData({ isActive: false, direction: BlockDirection.None }));
+      Signal.set(
+        callerNamespace,
+        entity,
+        SignalData({ isActive: false, direction: BlockDirection.None, hasValue: true })
+      );
     }
 
     return Signal.get(callerNamespace, entity);

--- a/packages/extension-contracts/src/test/systems/PoweredSystem.t.sol
+++ b/packages/extension-contracts/src/test/systems/PoweredSystem.t.sol
@@ -29,7 +29,7 @@ contract PoweredSystemTest is MudV2Test {
     bytes32 centerEntityId = bytes32(uint256(1));
     bytes32[] memory neighbourEntityIds = new bytes32[](6);
 
-    world.tenet_PoweredSystem_eventHandler(centerEntityId, neighbourEntityIds);
+    world.extension_PoweredSystem_eventHandler(centerEntityId, neighbourEntityIds);
 
     // assertEq(counter, 2);
   }


### PR DESCRIPTION
- We can't install non-root modules yet but the only module we were using is hasKeys and this shows how to not use it and just use a flag. This bloats storage BUT you can deploy your own namespace then