### PR TITLE
Cleanup create input system

### DIFF
--- a/packages/client/src/layers/noa/systems/createInputSystem.ts
+++ b/packages/client/src/layers/noa/systems/createInputSystem.ts
@@ -54,7 +54,7 @@ export function createInputSystem(layers: Layers) {
     plugins: ";",
     spawn: "O",
     preteleport: "P",
-    spawnCreation: "<enter>",
+    "spawn-creation": "<enter>",
     crouch: "<shift>",
   };
 
@@ -415,8 +415,8 @@ export function createInputSystem(layers: Layers) {
     });
   });
 
-  bindInputEvent("spawnCreation");
-  onDownInputEvent("spawnCreation", () => {
+  bindInputEvent("spawn-creation");
+  onDownInputEvent("spawn-creation", () => {
     if (!noa.container.hasPointerLock) {
       return;
     }


### PR DESCRIPTION
- I made all the inputs in the inputSystem use helper functions rather than call the noa event handlers directly
- this allows us to typecheck the input events to ensure that there ARE input buttons defined for that event
- by also consolidating these inputs into an object, it makes it easier for us to support custom keybindings in the future