### PR TITLE
fix falling in ground when you change the scale

### DIFF
--- a/packages/client/src/layers/react/components/PersistentSidebar.tsx
+++ b/packages/client/src/layers/react/components/PersistentSidebar.tsx
@@ -299,7 +299,13 @@ export function registerPersistentSidebar() {
           setComponent(WorldScale, SingletonID, { value: newWorldScale});
 
           const position = playerPosition$.getValue();
-          teleport(getNewPosition(position));
+
+          // If we teleport too soon, the player will teleport to the right spot, but noa will unload the world
+          // so the player falls down.  Then the world loads again, but by then, we've fallen down by one block
+          setTimeout(() => {
+            // note: this logic is buggy if the user spams the scale button a lot, but it's much simpler than trying to keep track of the user's gravity multiplier
+            teleport(getNewPosition(position));
+          }, 2000)
         }, 200);
       };
 
@@ -311,13 +317,8 @@ export function registerPersistentSidebar() {
       const zoomOut = (event: React.MouseEvent<HTMLDivElement>) => {
         (event.target as HTMLElement).blur();
         setScale(+1, (playerPosition) => {
-          const newPosition = getPositionInLevelAbove(playerPosition);
-          if (playerPosition.y === 1) {
-            // they were on the ground floor
-            // give them extra y so the user doesn't get stuck in the terrain
-            newPosition.y += 1;
-          }
-          return newPosition;
+          playerPosition.y += 1; // add one since we are dividing the player's y by 2
+          return getPositionInLevelAbove(playerPosition);
         });
       };
 
@@ -443,7 +444,7 @@ export function registerPersistentSidebar() {
                 </div>
                 <hr style={{ borderTop: "1px solid rgb(201, 202, 203, 0.5)", marginBottom: "4px" }} />
                 <div>
-                  {/* {position && (
+                   {/*{position && (
                     <span>
                       <span>
                         <span


### PR DESCRIPTION
why it was happening: when the world changes, noa unloads teh current world, which means that there are no blocks. so when the blocks are unloaded, the player falls. But then the new world is loaded and you stop falling. This is why players typically fall down one block.

an alternative scheme I wrote that will disable the user's gravity when teleporting (but only if they are not flying)

          const userHasGravity = body.gravityMultiplier !== 0; 
          if(userHasGravity){
            body.gravityMultiplier = 0; // set the gravity to 0 since after we teleport, the world unloads and the player falls down before the world loads back again
            // only after a delay do we enable gravity again
            teleport(getNewPosition(position));
            setTimeout(() => {
              body.gravityMultiplier = GRAVITY_MULTIPLIER;
            }, 2000)
          }else{
            teleport(getNewPosition(position));
          }