### PR TITLE
added caEntity versions of functions to move, mind, and build

### DIFF
--- a/examples/basic-conserved-world/packages/world/src/systems/BuildSystem.sol
+++ b/examples/basic-conserved-world/packages/world/src/systems/BuildSystem.sol
@@ -9,11 +9,12 @@ import { hasKey } from "@latticexyz/world/src/modules/keysintable/hasKey.sol";
 import { OwnedBy, VoxelType, WorldConfig } from "@tenet-world/src/codegen/Tables.sol";
 import { VoxelCoord, VoxelTypeData, VoxelEntity, EntityEventData } from "@tenet-utils/src/Types.sol";
 import { min } from "@tenet-utils/src/VoxelCoordUtils.sol";
-import { REGISTRY_ADDRESS, SIMULATOR_ADDRESS } from "@tenet-world/src/Constants.sol";
+import { REGISTRY_ADDRESS, SIMULATOR_ADDRESS, BASE_CA_ADDRESS } from "@tenet-world/src/Constants.sol";
 import { AirVoxelID } from "@tenet-level1-ca/src/Constants.sol";
 import { BuildWorldEventData } from "@tenet-world/src/Types.sol";
 import { onBuild, postTx } from "@tenet-simulator/src/CallUtils.sol";
 import { VoxelTypeRegistry, VoxelTypeRegistryData } from "@tenet-registry/src/codegen/tables/VoxelTypeRegistry.sol";
+import { CAEntityReverseMapping } from "@tenet-base-ca/src/codegen/tables/CAEntityReverseMapping.sol";
 
 contract BuildSystem is BuildEvent {
   function getRegistryAddress() internal pure override returns (address) {
@@ -42,6 +43,16 @@ contract BuildSystem is BuildEvent {
         coord,
         abi.encode(BuildEventData({ mindSelector: mindSelector, worldData: abi.encode(buildEventData) }))
       );
+  }
+
+  function buildWithAgentCaEntity(
+    bytes32 voxelTypeId,
+    VoxelCoord memory coord,
+    bytes32 caEntity,
+    bytes4 mindSelector
+  ) public returns (VoxelEntity memory) {
+    bytes32 entity = CAEntityReverseMapping.getEntity(IStore(BASE_CA_ADDRESS), caEntity);
+    return buildWithAgent(voxelTypeId, coord, VoxelEntity({ scale: 1, entityId: entity }), mindSelector);
   }
 
   function postEvent(

--- a/examples/basic-conserved-world/packages/world/src/systems/MineSystem.sol
+++ b/examples/basic-conserved-world/packages/world/src/systems/MineSystem.sol
@@ -10,9 +10,10 @@ import { VoxelType, OfSpawn, Spawn, SpawnData, WorldConfig } from "@tenet-world/
 import { MineEventData } from "@tenet-base-world/src/Types.sol";
 import { AirVoxelID } from "@tenet-level1-ca/src/Constants.sol";
 import { getEntityAtCoord } from "@tenet-base-world/src/Utils.sol";
-import { REGISTRY_ADDRESS, SIMULATOR_ADDRESS } from "@tenet-world/src/Constants.sol";
+import { REGISTRY_ADDRESS, SIMULATOR_ADDRESS, BASE_CA_ADDRESS } from "@tenet-world/src/Constants.sol";
 import { MineWorldEventData } from "@tenet-world/src/Types.sol";
 import { onMine, postTx } from "@tenet-simulator/src/CallUtils.sol";
+import { CAEntityReverseMapping } from "@tenet-base-ca/src/codegen/tables/CAEntityReverseMapping.sol";
 
 contract MineSystem is MineEvent {
   function getRegistryAddress() internal pure override returns (address) {
@@ -31,6 +32,15 @@ contract MineSystem is MineEvent {
   ) public returns (VoxelEntity memory) {
     MineWorldEventData memory mineEventData = MineWorldEventData({ agentEntity: agentEntity });
     return super.mine(voxelTypeId, coord, abi.encode(MineEventData({ worldData: abi.encode(mineEventData) })));
+  }
+
+  function mineWithAgentCaEntity(
+    bytes32 voxelTypeId,
+    VoxelCoord memory coord,
+    bytes32 caEntity
+  ) public returns (VoxelEntity memory) {
+    bytes32 entity = CAEntityReverseMapping.getEntity(IStore(BASE_CA_ADDRESS), caEntity);
+    return mineWithAgent(voxelTypeId, coord, VoxelEntity({ scale: 1, entityId: entity }));
   }
 
   function postEvent(

--- a/examples/basic-conserved-world/packages/world/src/systems/MoveSystem.sol
+++ b/examples/basic-conserved-world/packages/world/src/systems/MoveSystem.sol
@@ -6,7 +6,7 @@ import { MoveEvent } from "@tenet-base-world/src/prototypes/MoveEvent.sol";
 import { hasKey } from "@latticexyz/world/src/modules/keysintable/hasKey.sol";
 import { IWorld } from "@tenet-world/src/codegen/world/IWorld.sol";
 import { VoxelCoord, VoxelEntity, EntityEventData } from "@tenet-utils/src/Types.sol";
-import { REGISTRY_ADDRESS, SIMULATOR_ADDRESS } from "@tenet-world/src/Constants.sol";
+import { REGISTRY_ADDRESS, SIMULATOR_ADDRESS, BASE_CA_ADDRESS } from "@tenet-world/src/Constants.sol";
 import { MoveEventData } from "@tenet-base-world/src/Types.sol";
 import { isEntityEqual } from "@tenet-utils/src/Utils.sol";
 import { OwnedBy, OwnedByTableId, WorldConfig } from "@tenet-world/src/codegen/Tables.sol";
@@ -14,6 +14,7 @@ import { getEntityAtCoord } from "@tenet-base-world/src/Utils.sol";
 import { MoveWorldEventData } from "@tenet-world/src/Types.sol";
 import { onMove, postTx } from "@tenet-simulator/src/CallUtils.sol";
 import { console } from "forge-std/console.sol";
+import { CAEntityReverseMapping } from "@tenet-base-ca/src/codegen/tables/CAEntityReverseMapping.sol";
 
 contract MoveSystem is MoveEvent {
   function getRegistryAddress() internal pure override returns (address) {
@@ -48,6 +49,16 @@ contract MoveSystem is MoveEvent {
     }
 
     return (oldEntity, newEntity);
+  }
+
+  function moveWithAgentCaEntity(
+    bytes32 voxelTypeId,
+    VoxelCoord memory oldCoord,
+    VoxelCoord memory newCoord,
+    bytes32 caEntity
+  ) public returns (VoxelEntity memory, VoxelEntity memory) {
+    bytes32 entity = CAEntityReverseMapping.getEntity(IStore(BASE_CA_ADDRESS), caEntity);
+    return moveWithAgent(voxelTypeId, oldCoord, newCoord, VoxelEntity({ scale: 1, entityId: entity }));
   }
 
   function postEvent(


### PR DESCRIPTION
- added a version of move, build, and mine where you pass in the caEntity, rather than the voxelEntity.
  - This makes it really simple for our export transaction script (build_quickly) to send transactions to the chain for a specific caEntity, rather than waiting to sync with the server